### PR TITLE
patch jquery.shorten plugin to be jquery 3.5 compatible

### DIFF
--- a/src/jquery.shorten.js
+++ b/src/jquery.shorten.js
@@ -131,7 +131,7 @@
                             }
                         }
                     }
-                    c = $('<div>').html(bag + '<span class="ellip">' + config.ellipsesText + '</span></div>').html();
+                    c = $('<div></div>').html(bag + '<span class="ellip">' + config.ellipsesText + '</span>').html();
                 }else{
                     c+=config.ellipsesText;
                 }

--- a/src/jquery.shorten.js
+++ b/src/jquery.shorten.js
@@ -131,7 +131,7 @@
                             }
                         }
                     }
-                    c = $('<div/>').html(bag + '<span class="ellip">' + config.ellipsesText + '</span>').html();
+                    c = $('<div>').html(bag + '<span class="ellip">' + config.ellipsesText + '</span></div>').html();
                 }else{
                     c+=config.ellipsesText;
                 }


### PR DESCRIPTION
patch jquery.shorten plugin to be jquery 3.5 compatible, replacing `<div/>` with `<div></div>` per https://jquery.com/upgrade-guide/3.5/

As far as I can find, jquery.shorten is only used here: https://github.com/MoveOnOrg/ak-js/blob/master/build/ak-js.js#L326 and applied to the add-more-link css class, which according to an actionkit template search is only used in a few places:

1. in main-giraffe, just event_attendee_tools.html
![image](https://user-images.githubusercontent.com/2147383/89457646-b056bd80-d733-11ea-9fde-1b84bbeb0afd.png)

2. in mo-original, just event_attend.html, event_attendee_tools.html event_search_results.html
![image](https://user-images.githubusercontent.com/2147383/89457658-b6e53500-d733-11ea-9cb7-5334f0f65723.png)
