### PR TITLE
Changes to support Unsubscribe Thank You page

### DIFF
--- a/src/phone_sms_terms.js
+++ b/src/phone_sms_terms.js
@@ -59,7 +59,7 @@ var SMS_SUB_ERR_KEY = 'sms_subscribed:invalid';
 var mobilePhoneUpdate = function() {
   if ($(this).val().replace(/\D/g, '').length >= 10) {
     var phonemobile = ($(SMS_SUBSCRIBE_DIV).attr('data-phonemobile') || '');
-    if (/opt-out/.test(phonemobile)) {
+    if (/opt-out/.test(phonemobile) && !/opt-out-require-email/.test(phonemobile)) {
       $('#id_sms_subscribed').prop('checked', true);
       $('#id_sms_subscribed').val('sms_subscribed');
     }
@@ -76,18 +76,18 @@ $('input[name=phone],input[name=mobile_phone]')
   .on('change unfocus', mobilePhoneUpdate)
   .each(mobilePhoneUpdate);
 
-//onINPUT
-$('input[name=phone].fast-sms-opt-in')
-  .on('input', showSmsOptIn);
-
-$('input[name=user_sms_subscribed]')
-  .on('click', function() {
+  $('input[name=user_sms_subscribed]')
+  .on('change', function() {
     if (actionkit.errors) {
       if (actionkit.errors.hasOwnProperty(SMS_SUB_ERR_KEY)) {
         delete actionkit.errors[SMS_SUB_ERR_KEY];
       }
     }
   });
+
+//onINPUT
+$('input[name=phone].fast-sms-opt-in')
+  .on('input', showSmsOptIn);
 
 //onSUBMIT
 $('form[name=act]').on('actionkitbeforevalidation', function() {
@@ -98,6 +98,8 @@ $('form[name=act]').on('actionkitbeforevalidation', function() {
     mobile = '';
   }
   mobile = mobile.replace(/\D/g, '');
+  var phonemobile = ($(SMS_SUBSCRIBE_DIV).attr('data-phonemobile') || '');
+  var email_required = /opt-out-require-email/.test(phonemobile);
   var sms_opt_in_required = ($(SMS_SUBSCRIBE_DIV).attr('data-smsrequired') || '') === 'sms_opt_in_required';
 
   if (sms_opt_in_required && !mobile_subscribe) {
@@ -106,9 +108,6 @@ $('form[name=act]').on('actionkitbeforevalidation', function() {
     }
     actionkit.errors[SMS_SUB_ERR_KEY] = 'Please agree to the SMS terms by checking the box.';
   }
-
-  var phonemobile = ($(SMS_SUBSCRIBE_DIV).attr('data-phonemobile') || '');
-  var email_required = /opt-out-require-email/.test(phonemobile);
 
   if (mobile_subscribe && mobile && mobile.length >= 10) {
     if (window.console) {console.log('in mobile pathway, before validation');}

--- a/src/phone_sms_terms.js
+++ b/src/phone_sms_terms.js
@@ -71,19 +71,31 @@ var showSmsOptIn = function() {
   $(SMS_SUBSCRIBE_DIV).removeClass('d-none');
 }
 
+var validateSmsOptIn = function() {
+  var sms_opt_in_required = ($(SMS_SUBSCRIBE_DIV).attr('data-smsrequired') || '') === 'sms_opt_in_required';
+  var mobile_subscribe = $('#id_sms_subscribed', SMS_SUBSCRIBE_DIV).prop('checked');
+
+  if (!actionkit.errors) {
+    actionkit.errors = {};
+  }
+  if (sms_opt_in_required && !mobile_subscribe) {
+    actionkit.errors[SMS_SUB_ERR_KEY] = 'Please agree to the SMS terms by checking the box.';
+  }
+  else {
+    if (actionkit.errors.hasOwnProperty(SMS_SUB_ERR_KEY)) {
+      delete actionkit.errors[SMS_SUB_ERR_KEY];
+    }
+  }
+}
+
 // onCHANGE
 $('input[name=phone],input[name=mobile_phone]')
   .on('change unfocus', mobilePhoneUpdate)
   .each(mobilePhoneUpdate);
 
-  $('input[name=user_sms_subscribed]')
-  .on('change', function() {
-    if (actionkit.errors) {
-      if (actionkit.errors.hasOwnProperty(SMS_SUB_ERR_KEY)) {
-        delete actionkit.errors[SMS_SUB_ERR_KEY];
-      }
-    }
-  });
+// onCHANGE
+$('#id_sms_subscribed')
+  .on('change', validateSmsOptIn);
 
 //onINPUT
 $('input[name=phone].fast-sms-opt-in')
@@ -100,14 +112,8 @@ $('form[name=act]').on('actionkitbeforevalidation', function() {
   mobile = mobile.replace(/\D/g, '');
   var phonemobile = ($(SMS_SUBSCRIBE_DIV).attr('data-phonemobile') || '');
   var email_required = /opt-out-require-email/.test(phonemobile);
-  var sms_opt_in_required = ($(SMS_SUBSCRIBE_DIV).attr('data-smsrequired') || '') === 'sms_opt_in_required';
-
-  if (sms_opt_in_required && !mobile_subscribe) {
-    if (!actionkit.errors) {
-      actionkit.errors = {};
-    }
-    actionkit.errors[SMS_SUB_ERR_KEY] = 'Please agree to the SMS terms by checking the box.';
-  }
+  
+  validateSmsOptIn();
 
   if (mobile_subscribe && mobile && mobile.length >= 10) {
     if (window.console) {console.log('in mobile pathway, before validation');}
@@ -131,14 +137,8 @@ $('form.external-ak').on('submit', function() {
   var mobile_subscribe = $('#id_sms_subscribed', SMS_SUBSCRIBE_DIV).prop('checked');
   var phonemobile = ($(SMS_SUBSCRIBE_DIV).attr('data-phonemobile') || '');
   var email_required = /opt-out-require-email/.test(phonemobile);
-  var sms_opt_in_required = ($(SMS_SUBSCRIBE_DIV).attr('data-smsrequired') || '') === 'sms_opt_in_required';
 
-  if (sms_opt_in_required && !mobile_subscribe) {
-    if (!actionkit.errors) {
-      actionkit.errors = {};
-    }
-    actionkit.errors[SMS_SUB_ERR_KEY] = 'Please agree to the SMS terms by checking the box.';
-  }
+  validateSmsOptIn();
 
   if (mobile_subscribe && mobile && mobile.length >= 10) {
     if ($('#id_email').val() === '' && !email_required) {


### PR DESCRIPTION
Changes to support new behavior related to the Phone input field and SMS Opt-In checkbox on the new Unsubscribe Thank You page.

These changes are compiled to s3://actionkit.moveon.org/static/js/unsub-alex-ak-js.min.js

The following page is set up to use a TemplateSet with related HTML changes that interact with the changes here: https://act.moveon.org/admin/core/surveypage/67363/change/

To see actually use the new .js file, append the following query parameter: `akjsdev=unsub-alex`

One question for reviewers: Is there a better way to associate a custom ak-js.min.js file with an ActionKit page, rather than using a query parameter? I think QA will find it difficult to test this way, since the parameter does not seem to carry over from the unsubscribe page to the thank-you page. QA will need to remember to apply it there.