### PR TITLE
Show SMS terms for recognized user

### DIFF
--- a/src/phone_sms_terms.js
+++ b/src/phone_sms_terms.js
@@ -55,6 +55,15 @@ var SMS_SUBSCRIBE_DIV = '#id_subscribe_sms';
 })();
 
 var mobilePhoneUpdate = function() {
+    // if #id_subscribe_sms is not next to #fieldbox-phone then move it
+    if ($('#fieldbox-phone').siblings(SMS_SUBSCRIBE_DIV).length != 1) {
+      $('#fieldbox-phone').parent().append($(SMS_SUBSCRIBE_DIV));
+      // There's a weird bug where the checkbox also isn't present for a recognized AKID; add it back in if it's missing
+      if ($('#id_sms_subscribed').length == 0) {
+        $(SMS_SUBSCRIBE_DIV).prepend('<input id="id_sms_subscribed" type="checkbox" name="user_sms_subscribed"></input>')
+      }
+    }
+
   if ($(this).val().replace(/\D/g, '').length >= 10) {
     var phonemobile = ($(SMS_SUBSCRIBE_DIV).attr('data-phonemobile') || '');
     if (/opt-out/.test(phonemobile)) {


### PR DESCRIPTION
Do some extra fiddling around with jQuery to make sure the SMS terms and conditions div is always next to the phone number div, and to add the checkbox back in if it goes missing.

Test with page https://act.moveon.org/cms/thanks/test-phone-required / https://act.moveon.org/survey/test-phone-required/?akid=.46558316.ZQz0XS / https://act.moveon.org/admin/core/surveypage/92443/change/